### PR TITLE
Add CMake support to C++ bindings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bindings/cpp/pybind11"]
+	path = bindings/cpp/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,15 +1,61 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(data_pipeline_cpp
+  VERSION "0.1.0"
   LANGUAGES CXX)
 
+set(PYBIND11_INSTALL ON CACHE BOOL "")
 add_subdirectory(pybind11)
+
+set(DATA_PIPELINE_HEADERS table.hh datapipeline.hh)
 
 add_library(data_pipeline_cpp
   table.cc datapipeline.cc
-  table.hh datapipeline.hh)
+  ${DATA_PIPELINE_HEADERS})
 target_link_libraries(data_pipeline_cpp PUBLIC pybind11::embed)
 
 add_executable(test_datapipeline
   test_datapipeline.cc)
 target_link_libraries(test_datapipeline data_pipeline_cpp)
+
+##################################################
+# Installation
+
+include(GNUInstallDirs)
+install(TARGETS data_pipeline_cpp
+  EXPORT data_pipeline_cppTargets
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
+install(FILES ${DATA_PIPELINE_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  data_pipeline_cppConfigVersion.cmake
+  VERSION ${PACKAGE_VERSION}
+  COMPATIBILITY SameMajorVersion
+  )
+
+# This is a workaround for pybind11 not currently installing its targets
+# Definitely should be removed if that changes
+install(EXPORT "pybind11Targets"
+  NAMESPACE "pybind11::"
+  DESTINATION ${PYBIND11_CMAKECONFIG_INSTALL_DIR})
+
+install(EXPORT data_pipeline_cppTargets
+  FILE data_pipeline_cppTargets.cmake
+  NAMESPACE data_pipeline_cpp::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/data_pipeline_cpp"
+  )
+
+configure_package_config_file(data_pipeline_cppConfig.cmake.in data_pipeline_cppConfig.cmake
+  INSTALL_DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/data_pipeline_cppConfig.cmake"
+  )
+install(
+  FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/data_pipeline_cppConfig.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/data_pipeline_cppConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/data_pipeline_cpp"
+  )

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(data_pipeline_cpp
+  LANGUAGES CXX)
+
+add_subdirectory(pybind11)
+
+add_library(data_pipeline_cpp
+  table.cc datapipeline.cc
+  table.hh datapipeline.hh)
+target_link_libraries(data_pipeline_cpp PUBLIC pybind11::embed)
+
+add_executable(test_datapipeline
+  test_datapipeline.cc)
+target_link_libraries(test_datapipeline data_pipeline_cpp)

--- a/bindings/cpp/data_pipeline_cppConfig.cmake.in
+++ b/bindings/cpp/data_pipeline_cppConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(pybind11)
+
+include("${CMAKE_CURRENT_LIST_DIR}/data_pipeline_cppTargets.cmake")


### PR DESCRIPTION
This adds a pretty basic CMake file for the C++ bindings branch. The pybind11 submodule basically takes care of all the fun of finding python for us.

Unfortunately pybind11 does a couple of things strangely, so it doesn't currently seem possible to use the build directory directly. This means the pipeline bindings need to be installed:

    cmake . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/build/install

A minimal `CMakeLists.txt` to use this would be:

```cmake
cmake_minimum_required(VERSION 3.12)

project(data_pipeline_cpp_test
  VERSION "0.1.0"
  LANGUAGES CXX)

find_package(data_pipeline_cpp REQUIRED)

add_executable(test_datapipeline
  test_datapipeline.cc)
target_link_libraries(test_datapipeline data_pipeline_cpp::data_pipeline_cpp)
```

and configured like:

    cmake . -B build -DCMAKE_PREFIX_PATH=/path/to/installed/bindings
