### PR TITLE
Scrc 531 copy config yaml to access yaml

### DIFF
--- a/data_pipeline_api/file_formats/parameter_file.py
+++ b/data_pipeline_api/file_formats/parameter_file.py
@@ -55,7 +55,9 @@ def read_estimate(file: TextIOBase, component: str) -> Estimate:
 
 
 def write_estimate(file: TextIOBase, component: str, estimate: Estimate):
-    write_parameter(file, component, {"type": "point-estimate", "value": estimate})
+    write_parameter(
+        file, component, {"type": "point-estimate", "value": float(estimate)}
+    )
 
 
 # ======================================================================================

--- a/examples/standard_api_usage.py
+++ b/examples/standard_api_usage.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from scipy.stats import gamma
 from pathlib import Path
@@ -6,17 +7,49 @@ from data_pipeline_api.standard_api import StandardAPI
 CONFIG_PATH = Path(__file__).parent.parent / "tests" / "data" / "config.yaml"
 
 with StandardAPI(CONFIG_PATH) as api:
-    print(api.read_estimate("parameter", "example-estimate"))
-    print(api.read_estimate("parameter", "example-distribution"))
-    print(api.read_estimate("parameter", "example-samples"))
+    api.write_estimate(
+        "output-parameter",
+        "example-estimate-from-estimate",
+        api.read_estimate("parameter", "example-estimate"),
+    )
+    api.write_estimate(
+        "output-parameter",
+        "example-estimate-from-distribution",
+        api.read_estimate("parameter", "example-distribution"),
+    )
+    api.write_estimate(
+        "output-parameter",
+        "example-estimate-from-samples",
+        api.read_estimate("parameter", "example-samples"),
+    )
 
     # print(api.read_distribution("parameter", "example-estimate"))  # expected to fail
-    print(api.read_distribution("parameter", "example-distribution"))
+    api.write_distribution(
+        "output-parameter",
+        "example-distribution",
+        api.read_distribution("parameter", "example-distribution"),
+    )
     # print(api.read_distribution("parameter", "example-samples"))  # expected to fail
-    
-    print(api.read_sample("parameter", "example-estimate"))
-    print(api.read_sample("parameter", "example-distribution"))
-    print(api.read_sample("parameter", "example-samples"))
-    
-    print(api.read_table("object", "example-table"))
-    print(api.read_array("object", "example-array"))
+
+    api.write_samples(
+        "output-parameter",
+        "example-samples-from-estimate",
+        np.array([api.read_sample("parameter", "example-estimate")]),
+    )
+    api.write_samples(
+        "output-parameter",
+        "example-samples-from-distribution",
+        np.array([api.read_sample("parameter", "example-distribution")]),
+    )
+    api.write_samples(
+        "output-parameter",
+        "example-samples-from-samples",
+        np.array([api.read_sample("parameter", "example-samples")]),
+    )
+
+    api.write_table(
+        "output-object", "example-table", api.read_table("object", "example-table")
+    )
+    api.write_array(
+        "output-object", "example-array", api.read_array("object", "example-array")
+    )

--- a/tests/file_formats/test_parameter_file.py
+++ b/tests/file_formats/test_parameter_file.py
@@ -38,6 +38,15 @@ def test_estimate_roundtrip(tmp_path):
         assert parameter_file.read_estimate(TextIOWrapper(file), "test") == estimate
 
 
+def test_write_np_float_estimate(tmp_path):
+    estimate = np.float64(3)
+    with open(tmp_path / "test.toml", "w+b") as file:
+        parameter_file.write_estimate(TextIOWrapper(file), "test", estimate)
+    with open(tmp_path / "test.toml", "r+b") as file:
+        assert parameter_file.read_estimate(TextIOWrapper(file), "test") == estimate
+
+
+
 def test_distribution_roundtrip(tmp_path):
     distribution = stats.gamma(1, scale=2)
     with open(tmp_path / "test.toml", "w+b") as file:

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 from data_pipeline_api.file_api import FileAPI
 
+
 @pytest.fixture
 def configuration_file(tmp_path: Path) -> Path:
     with open(tmp_path / "version1.txt", "w") as file:
@@ -62,3 +63,64 @@ def test_write(tmp_path: Path, configuration_file: Path):
 # TODO : test metadata loading.
 # TODO : test for behaviour when we can't find a filename.
 # TODO : test for behaviour when we can't find a file.
+
+
+def test_access_log_written_if_not_set(tmp_path):
+    configuration_file = tmp_path / "config.yaml"
+    with open(configuration_file, "w") as file:
+        file.write(
+            """
+data_directory: .
+run_id: test
+fail_on_hash_mismatch: False
+"""
+        )
+    with FileAPI(configuration_file):
+        pass
+    assert (tmp_path / "access-test.yaml").exists()
+
+
+def test_access_log_written_if_set_to_path(tmp_path):
+    configuration_file = tmp_path / "config.yaml"
+    with open(configuration_file, "w") as file:
+        file.write(
+            """
+data_directory: .
+access_log: access.yaml
+fail_on_hash_mismatch: False
+"""
+        )
+    with FileAPI(configuration_file):
+        pass
+    assert (tmp_path / "access.yaml").exists()
+
+
+def test_access_log_not_written_if_set_to_False(tmp_path):
+    configuration_file = tmp_path / "config.yaml"
+    with open(configuration_file, "w") as file:
+        file.write(
+            """
+data_directory: .
+access_log: False
+fail_on_hash_mismatch: False
+"""
+        )
+    with FileAPI(configuration_file):
+        pass
+    assert not (tmp_path / "access.yaml").exists()
+
+
+def test_access_log_written_if_set_to_absolute_path(tmp_path):
+    configuration_file = tmp_path / "config.yaml"
+    access_file_path = tmp_path / "access.yaml"
+    with open(configuration_file, "w") as file:
+        file.write(
+            f"""
+data_directory: .
+access_log: {str(access_file_path.resolve())}
+fail_on_hash_mismatch: False
+"""
+        )
+    with FileAPI(configuration_file):
+        pass
+    assert access_file_path.exists()


### PR DESCRIPTION
Address three open tickets:
[SCRC-503](https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/503)
[SCRC-505](https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/505)
[SCRC-531](https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/531)

Also fixes a bug in writing estimates (numpy floats were serialised as strings by the toml serialiser), and expands the example script.
