### PR TITLE
SCRC-589 Added run metadata mechanism to file API to allow us to propagate model uri and git sha to upload script.

### DIFF
--- a/data_pipeline_api/file_api.py
+++ b/data_pipeline_api/file_api.py
@@ -72,6 +72,8 @@ class FileAPI:
         self._open_timestamp = datetime.now()
         logger.debug("open_timestamp = %s", self._open_timestamp)
         self._accesses = []
+        self._run_metadata = {}
+
         config_filename = Path(config_filename)
         config_root = config_filename.parent
 
@@ -230,6 +232,11 @@ class FileAPI:
         file.close = close
         return file
 
+    def set_metadata(self, key, value):
+        """Set run-level metadata.
+        """
+        self._run_metadata[key] = value
+
     def close(self):
         """Close the session and write the access log.
         """
@@ -242,6 +249,7 @@ class FileAPI:
                         "close_timestamp": datetime.now(),
                         "run_id": self.run_id,
                         "config": self._config,
+                        "metadata": self._run_metadata,
                         "io": self._accesses,
                     },
                     output_file,

--- a/data_pipeline_api/metadata.py
+++ b/data_pipeline_api/metadata.py
@@ -1,5 +1,4 @@
-from typing import Mapping, Optional
-from pathlib import Path
+from typing import Mapping
 
 Metadata = Mapping[str, str]
 

--- a/data_pipeline_api/standard_api.py
+++ b/data_pipeline_api/standard_api.py
@@ -1,10 +1,9 @@
 from io import TextIOWrapper
 from pathlib import Path
 from contextlib import contextmanager
+from typing import Union
 import numpy as np
-import pandas as pd
 from data_pipeline_api.file_api import FileAPI
-from data_pipeline_api.file_formats import parameter_file
 from data_pipeline_api.file_formats.parameter_file import (
     Type,
     Estimate,
@@ -20,7 +19,6 @@ from data_pipeline_api.file_formats.parameter_file import (
 )
 from data_pipeline_api.file_formats.object_file import (
     Array,
-    Dimension,
     Table,
     read_array,
     read_table,
@@ -29,22 +27,41 @@ from data_pipeline_api.file_formats.object_file import (
 )
 
 
-class StandardAPI(FileAPI):
+class StandardAPI:
+    """The StandardAPI class provides access to data products conforming to the Standard
+    API specification.
+    """
+    def __init__(self, config_filename: Union[Path, str], uri: str, git_sha: str):
+        self.file_api = FileAPI(config_filename)
+        self.file_api.set_metadata("uri", uri)
+        self.file_api.set_metadata("git_sha", git_sha)
+
+    def __enter__(self):
+        self.file_api.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self.file_api.__exit__(exc_type, exc_value, traceback)
+
     # ==================================================================================
     # Parameter files
     # ==================================================================================
 
     @contextmanager
     def open_parameter_file_for_read(self, data_product: str, component: str):
+        """Open a parameter file for reading.
+        """
         with TextIOWrapper(
-            self.open_for_read(data_product=data_product, component=component)
+            self.file_api.open_for_read(data_product=data_product, component=component)
         ) as parameter_file:
             yield parameter_file
 
     @contextmanager
     def open_parameter_file_for_write(self, data_product: str, component: str):
+        """Open a parameter file for writing.
+        """
         with TextIOWrapper(
-            self.open_for_write(
+            self.file_api.open_for_write(
                 data_product=data_product, component=component, extension="toml"
             )
         ) as parameter_file:
@@ -54,23 +71,22 @@ class StandardAPI(FileAPI):
     # Estimate
     # ----------------------------------------------------------------------------------
 
-    def read_estimate(
-        self, data_product: str, component: str
-    ) -> Estimate:
+    def read_estimate(self, data_product: str, component: str) -> Estimate:
+        """Read an estimate from the data product component.
+        """
         with self.open_parameter_file_for_read(data_product, component) as file:
             parameter_type = read_type(file, component)
             if parameter_type is Type.POINT_ESTIMATE:
                 return read_estimate(file, component)
-            elif parameter_type is Type.DISTRIBUTION:
+            if parameter_type is Type.DISTRIBUTION:
                 return read_distribution(file, component).mean()
-            elif parameter_type is Type.SAMPLES:
+            if parameter_type is Type.SAMPLES:
                 return read_samples(file, component).mean()
-            else:
-                raise ValueError(f"unrecognised type {parameter_type}")
+            raise ValueError(f"unrecognised type {parameter_type}")
 
-    def write_estimate(
-        self, data_product: str, component: str, estimate: Estimate
-    ):
+    def write_estimate(self, data_product: str, component: str, estimate: Estimate):
+        """Write an estimate to the data product component.
+        """
         with self.open_parameter_file_for_write(data_product, component) as file:
             write_estimate(file, component, estimate)
 
@@ -78,26 +94,24 @@ class StandardAPI(FileAPI):
     # Distribution
     # ----------------------------------------------------------------------------------
 
-    def read_distribution(
-        self, data_product: str, component: str
-    ) -> Distribution:
+    def read_distribution(self, data_product: str, component: str) -> Distribution:
+        """Read a distribution from the data product component.
+        """
         with self.open_parameter_file_for_read(data_product, component) as file:
             parameter_type = read_type(file, component)
             if parameter_type is Type.POINT_ESTIMATE:
                 raise ValueError("point-estimate cannot be read as a distribution")
-            elif parameter_type is Type.DISTRIBUTION:
+            if parameter_type is Type.DISTRIBUTION:
                 return read_distribution(file, component)
-            elif parameter_type is Type.SAMPLES:
+            if parameter_type is Type.SAMPLES:
                 raise ValueError("samples cannot be read as a distribution")
-            else:
-                raise ValueError(f"unrecognised type {parameter_type}")
+            raise ValueError(f"unrecognised type {parameter_type}")
 
     def write_distribution(
-        self,
-        data_product: str,
-        component: str,
-        distribution: Distribution,
+        self, data_product: str, component: str, distribution: Distribution,
     ):
+        """Write a distribution to the data product component.
+        """
         with self.open_parameter_file_for_write(data_product, component) as file:
             write_distribution(file, component, distribution)
 
@@ -106,20 +120,21 @@ class StandardAPI(FileAPI):
     # ----------------------------------------------------------------------------------
 
     def read_sample(self, data_product: str, component: str) -> float:
+        """Read a sample from the data product component.
+        """
         with self.open_parameter_file_for_read(data_product, component) as file:
             parameter_type = read_type(file, component)
             if parameter_type is Type.POINT_ESTIMATE:
                 return read_estimate(file, component)
-            elif parameter_type is Type.DISTRIBUTION:
+            if parameter_type is Type.DISTRIBUTION:
                 return read_distribution(file, component).rvs()
-            elif parameter_type is Type.SAMPLES:
+            if parameter_type is Type.SAMPLES:
                 return np.random.choice(read_samples(file, component))
-            else:
-                raise ValueError(f"unrecognised type {parameter_type}")
+            raise ValueError(f"unrecognised type {parameter_type}")
 
-    def write_samples(
-        self, data_product: str, component: str, samples: Samples
-    ):
+    def write_samples(self, data_product: str, component: str, samples: Samples):
+        """Write samples to the data product component.
+        """
         with self.open_parameter_file_for_write(data_product, component) as file:
             write_samples(file, component, samples)
 
@@ -129,30 +144,42 @@ class StandardAPI(FileAPI):
 
     @contextmanager
     def open_object_file_for_read(self, data_product: str, component: str):
-        with self.open_for_read(
+        """Open an parameter file for reading.
+        """
+        with self.file_api.open_for_read(
             data_product=data_product, component=component
         ) as object_file:
             yield object_file
 
     @contextmanager
     def open_object_file_for_write(self, data_product: str, component: str):
-        with self.open_for_write(
+        """Open an parameter file for writing.
+        """
+        with self.file_api.open_for_write(
             data_product=data_product, component=component, extension="h5"
         ) as object_file:
             yield object_file
 
     def read_table(self, data_product: str, component: str) -> Table:
+        """Read a table from the data product component.
+        """
         with self.open_object_file_for_read(data_product, component) as file:
             return read_table(file, component)
 
     def write_table(self, data_product: str, component: str, table: Table):
+        """Write a table to the data product component.
+        """
         with self.open_object_file_for_write(data_product, component) as file:
             write_table(file, component, table)
 
     def read_array(self, data_product: str, component: str) -> Array:
+        """Read an array from the data product component.
+        """
         with self.open_object_file_for_read(data_product, component) as file:
             return read_array(file, component)
 
     def write_array(self, data_product: str, component: str, array: Array):
+        """Write an array to the data product component.
+        """
         with self.open_object_file_for_write(data_product, component) as file:
             write_array(file, component, array)

--- a/examples/standard_api_usage.py
+++ b/examples/standard_api_usage.py
@@ -1,8 +1,6 @@
 from logging import basicConfig
-import numpy as np
-import pandas as pd
-from scipy.stats import gamma
 from pathlib import Path
+import numpy as np
 from data_pipeline_api.standard_api import StandardAPI
 
 
@@ -13,7 +11,7 @@ basicConfig(
 
 CONFIG_PATH = Path(__file__).parent.parent / "tests" / "data" / "config.yaml"
 
-with StandardAPI(CONFIG_PATH) as api:
+with StandardAPI(CONFIG_PATH, "uri", "git_sha") as api:
     api.write_estimate(
         "output-parameter",
         "example-estimate-from-estimate",

--- a/tests/test_standard_api.py
+++ b/tests/test_standard_api.py
@@ -1,49 +1,56 @@
+# pylint: disable=redefined-outer-name,missing-function-docstring,import-error
+from pathlib import Path
 import pytest
+import yaml
 import numpy as np
 import pandas as pd
 from scipy import stats
-from pathlib import Path
 from data_pipeline_api.standard_api import StandardAPI, Array
 
 CONFIG_PATH = Path(__file__).parent / "data" / "config.yaml"
 
 
-def test_write_estimate():
-    StandardAPI(CONFIG_PATH).write_estimate("parameter", "example-estimate", 1.0)
+@pytest.fixture
+def standard_api():
+    return StandardAPI(CONFIG_PATH, "test_uri", "test_git_sha")
 
 
-def test_read_estimate_as_estimate():
-    assert (
-        StandardAPI(CONFIG_PATH).read_estimate("parameter", "example-estimate") == 1.0
-    )
+def test_write_estimate(standard_api):
+    with standard_api as api:
+        api.write_estimate("parameter", "example-estimate", 1.0)
 
 
-def test_read_estimate_as_distribution():
+def test_read_estimate_as_estimate(standard_api):
+    with standard_api as api:
+        assert api.read_estimate("parameter", "example-estimate") == 1.0
+
+
+def test_read_estimate_as_distribution(standard_api):
     with pytest.raises(ValueError):
-        StandardAPI(CONFIG_PATH).read_distribution("parameter", "example-estimate")
+        with standard_api as api:
+            api.read_distribution("parameter", "example-estimate")
 
 
-def test_read_estimate_as_sample():
-    assert StandardAPI(CONFIG_PATH).read_sample("parameter", "example-estimate") == 1.0
+def test_read_estimate_as_sample(standard_api):
+    with standard_api as api:
+        assert api.read_sample("parameter", "example-estimate") == 1.0
 
 
-def test_write_distribution():
-    StandardAPI(CONFIG_PATH).write_distribution(
+def test_write_distribution(standard_api):
+    with standard_api as api:
+        api.write_distribution(
         "parameter", "example-distribution", stats.gamma(1, scale=2)
     )
 
 
-def test_read_distribution_as_estimate():
-    assert (
-        StandardAPI(CONFIG_PATH).read_estimate("parameter", "example-distribution")
-        == 2.0
-    )
+def test_read_distribution_as_estimate(standard_api):
+    with standard_api as api:
+        assert api.read_estimate("parameter", "example-distribution") == 2.0
 
 
-def test_read_distribution_as_distribution():
-    distribution = StandardAPI(CONFIG_PATH).read_distribution(
-        "parameter", "example-distribution"
-    )
+def test_read_distribution_as_distribution(standard_api):
+    # pylint: disable=protected-access
+    distribution = standard_api.read_distribution("parameter", "example-distribution")
     assert distribution.dist._parse_args(*distribution.args, **distribution.kwds) == (
         (1.0,),
         0,
@@ -51,54 +58,67 @@ def test_read_distribution_as_distribution():
     )
 
 
-def test_read_distribution_as_sample():
+def test_read_distribution_as_sample(standard_api):
     np.random.seed(0)
-    assert (
-        StandardAPI(CONFIG_PATH).read_sample("parameter", "example-distribution")
+    with standard_api as api:
+        assert (
+        api.read_sample("parameter", "example-distribution")
         == 1.59174901632622
     )
 
 
-def test_write_samples():
-    StandardAPI(CONFIG_PATH).write_samples(
-        "parameter", "example-samples", np.array([1, 2, 3])
-    )
+def test_write_samples(standard_api):
+    with standard_api as api:
+        api.write_samples("parameter", "example-samples", np.array([1, 2, 3]))
 
 
-def test_read_samples_as_estimate():
-    assert StandardAPI(CONFIG_PATH).read_estimate("parameter", "example-samples") == 2.0
+def test_read_samples_as_estimate(standard_api):
+    with standard_api as api:
+        assert api.read_estimate("parameter", "example-samples") == 2.0
 
 
-def test_read_samples_as_distribution():
+def test_read_samples_as_distribution(standard_api):
     with pytest.raises(ValueError):
-        StandardAPI(CONFIG_PATH).read_distribution("parameter", "example-samples")
+        with standard_api as api:
+            api.read_distribution("parameter", "example-samples")
 
 
-def test_read_samples_as_sample():
+def test_read_samples_as_sample(standard_api):
     np.random.seed(0)
-    assert StandardAPI(CONFIG_PATH).read_sample("parameter", "example-samples") == 1.0
+    with standard_api as api:
+        assert api.read_sample("parameter", "example-samples") == 1.0
 
 
-def test_read_table():
-    pd.testing.assert_frame_equal(
-        StandardAPI(CONFIG_PATH).read_table("object", "example-table"),
-        pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
-    )
+def test_read_table(standard_api):
+    with standard_api as api:
+        pd.testing.assert_frame_equal(
+            api.read_table("object", "example-table"),
+            pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
+        )
 
 
-def test_read_array():
-    assert StandardAPI(CONFIG_PATH).read_array("object", "example-array") == Array(
-        np.array([1, 2, 3])
-    )
+def test_read_array(standard_api):
+    with standard_api as api:
+        assert api.read_array("object", "example-array") == Array(np.array([1, 2, 3]))
 
 
-def test_write_table():
-    StandardAPI(CONFIG_PATH).write_table(
-        "object", "example-table", pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    )
+def test_write_table(standard_api):
+    with standard_api as api:
+        api.write_table(
+            "object", "example-table", pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        )
 
 
-def test_write_array():
-    StandardAPI(CONFIG_PATH).write_array(
-        "object", "example-array", Array(np.array([1, 2, 3]))
-    )
+def test_write_array(standard_api):
+    with standard_api as api:
+        api.write_array("object", "example-array", Array(np.array([1, 2, 3])))
+
+
+def test_access_log_contains_uri_and_git_sha(standard_api):
+    with standard_api:
+        pass
+    with open(CONFIG_PATH.parent / "access-example.yaml") as access_file:
+        assert yaml.safe_load(access_file)["metadata"] == {
+            "uri": "test_uri",
+            "git_sha": "test_git_sha",
+        }


### PR DESCRIPTION
Some of the attributes in the access log (e.g. the `run_id`) could feasibly go in the `metadata` section, but I have left them where they are for now.

I took this opportunity to make it so the `StandardAPI` class is no longer a subclass of `FileAPI`, preventing us from inadvertently using any `FileAPI` methods.

I have added some (fairly trivial) notes on these changes into the file and standard API specs on teams.

@ianhinder, @vinopm, @ZedThree please account for these changes in your wrapper, reimplementation, and usage (respectively).

edit: This is targeting the logging branch until that is merged, to simplify the diff. I'm not sure how github handles that, if there is some better thing to do?