### PR TITLE
SCRC-635 Separate out distribution encoding function.

### DIFF
--- a/data_pipeline_api/file_formats/parameter_file.py
+++ b/data_pipeline_api/file_formats/parameter_file.py
@@ -79,7 +79,8 @@ def read_distribution(file: TextIOBase, component: str) -> Distribution:
         raise ValueError(f"{parameter['type']} != 'distribution'")
 
 
-def write_distribution(file: TextIOBase, component: str, distribution: Distribution):
+def encode_distribution(distribution: Distribution) -> Dict[str, Any]:
+    """Encode distribution into a serialisable format."""
     shape, loc, scale = distribution.dist._parse_args(
         *distribution.args, **distribution.kwds
     )
@@ -93,8 +94,13 @@ def write_distribution(file: TextIOBase, component: str, distribution: Distribut
         parameter["shape"] = shape[0]
     if scale:
         parameter["scale"] = scale
+    return parameter
+
+
+def write_distribution(file: TextIOBase, component: str, distribution: Distribution):
+    """Write distribution to file under component."""
     write_parameter(
-        file, component, parameter,
+        file, component, encode_distribution(distribution),
     )
 
 

--- a/tests/file_formats/test_parameter_file.py
+++ b/tests/file_formats/test_parameter_file.py
@@ -46,17 +46,29 @@ def test_write_np_float_estimate(tmp_path):
         assert parameter_file.read_estimate(TextIOWrapper(file), "test") == estimate
 
 
+def test_encode_distribution():
+    assert parameter_file.encode_distribution(stats.norm(loc=2, scale=3)) == {
+        "type": "distribution",
+        "distribution": "norm",
+        "loc": 2,
+        "scale": 3,
+    }
+
 
 def assert_distribution_roundtrip(tmp_path, distribution):
     with open(tmp_path / "test.toml", "w+b") as file:
-        parameter_file.write_distribution(TextIOWrapper(file), f"test-{distribution.dist.name}", distribution)
+        parameter_file.write_distribution(
+            TextIOWrapper(file), f"test-{distribution.dist.name}", distribution
+        )
 
     def representation(distribution):
         return distribution.dist._parse_args(*distribution.args, **distribution.kwds)
 
     with open(tmp_path / "test.toml", "r+b") as file:
         assert representation(
-            parameter_file.read_distribution(TextIOWrapper(file), f"test-{distribution.dist.name}")
+            parameter_file.read_distribution(
+                TextIOWrapper(file), f"test-{distribution.dist.name}"
+            )
         ) == representation(distribution)
 
 


### PR DESCRIPTION
You should now be able to call `data_pipeline_api.file_formats.parameter_file.encode_distribution(...)` with a distribution object to get back the encoded form.