### PR TITLE
Add registry package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     description="Interacts with SCRC data pipeline",
     author="SCRC",
     author_email="scrc@glasgow.ac.uk",
-    packages=["data_pipeline_api", "data_pipeline_api.file_formats"],
+    packages=["data_pipeline_api", "data_pipeline_api.file_formats", "data_pipeline_api.registry"],
     install_requires=_read_requirements(),
     setup_requires=["setuptools_scm", "pyyaml"],
     use_scm_version=True,


### PR DESCRIPTION
I think this is all that's needed to make the upload and download scripts available via CLI when the package is installed. I tested this by removing `data_pipeline_api` from my conda environment and reinstalling with pip from the repo with this hash:

```
python -m pip install git+https://github.com/ScottishCovidResponse/data_pipeline_api@a2a537694653bdff0a74028b5c78715abbb7bf69
```

Resolves https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/695