### PR TITLE
Underlying distribution should return deterministic samples

### DIFF
--- a/java_api/standard_api/src/main/java/uk/ramp/api/StandardApi.java
+++ b/java_api/standard_api/src/main/java/uk/ramp/api/StandardApi.java
@@ -63,6 +63,12 @@ public class StandardApi {
     }
   }
 
+  public Distribution readDistribution(String dataProduct, String component, long seed) {
+    var dist = readDistribution(dataProduct, component);
+    dist.underlyingDistribution().reseedRandomGenerator(seed);
+    return dist;
+  }
+
   public Distribution readDistribution(String dataProduct, String component) {
     var query =
         ImmutableMetadataItem.builder().dataProduct(dataProduct).component(component).build();

--- a/java_api/standard_api/src/main/java/uk/ramp/distribution/Distribution.java
+++ b/java_api/standard_api/src/main/java/uk/ramp/distribution/Distribution.java
@@ -19,8 +19,8 @@ import org.apache.commons.math3.distribution.RealDistribution;
 import org.apache.commons.math3.distribution.UniformRealDistribution;
 import org.apache.commons.math3.random.EmpiricalDistribution;
 import org.immutables.value.Value.Check;
-import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Lazy;
 import uk.ramp.parameters.Component;
 
 @JsonSerialize
@@ -108,7 +108,7 @@ public interface Distribution extends Component {
   }
 
   @JsonIgnore
-  @Derived
+  @Lazy
   default RealDistribution underlyingDistribution() {
     if (internalType().equals(DistributionType.gamma)) {
       return new GammaDistribution(internalShape().orElseThrow(), internalScale().orElseThrow());

--- a/java_api/standard_api/src/main/java/uk/ramp/distribution/Distribution.java
+++ b/java_api/standard_api/src/main/java/uk/ramp/distribution/Distribution.java
@@ -19,6 +19,7 @@ import org.apache.commons.math3.distribution.RealDistribution;
 import org.apache.commons.math3.distribution.UniformRealDistribution;
 import org.apache.commons.math3.random.EmpiricalDistribution;
 import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 import uk.ramp.parameters.Component;
 
@@ -107,6 +108,7 @@ public interface Distribution extends Component {
   }
 
   @JsonIgnore
+  @Derived
   default RealDistribution underlyingDistribution() {
     if (internalType().equals(DistributionType.gamma)) {
       return new GammaDistribution(internalShape().orElseThrow(), internalScale().orElseThrow());

--- a/java_api/standard_api/src/main/java/uk/ramp/distribution/Distribution.java
+++ b/java_api/standard_api/src/main/java/uk/ramp/distribution/Distribution.java
@@ -106,7 +106,8 @@ public interface Distribution extends Component {
     return this;
   }
 
-  private RealDistribution underlyingDistribution() {
+  @JsonIgnore
+  default RealDistribution underlyingDistribution() {
     if (internalType().equals(DistributionType.gamma)) {
       return new GammaDistribution(internalShape().orElseThrow(), internalScale().orElseThrow());
     } else if (internalType().equals(DistributionType.exponential)) {


### PR DESCRIPTION
The underlying distribution returned by the std api should produce deterministic samples. This is important for reproducibility.  