### PR TITLE
SCRC-704 All writes record latest hash.

### DIFF
--- a/scripts/convert_access_to_config.py
+++ b/scripts/convert_access_to_config.py
@@ -31,6 +31,9 @@ def convert_cli(access_filename, config_filename, use_filenames):
         for key in ("data_directory", "access_log", "run_id", "fail_on_hash_mismatch"):
             if key in access["config"]:
                 config[key] = access["config"][key]
+        # Copy run metadata.
+        if "run_metadata" in access:
+            config["run_metadata"] = access["run_metadata"]
         # Copy reads.
         reads = [
             {

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -1,7 +1,8 @@
-import pytest
 import logging
 from pathlib import Path
-from data_pipeline_api.file_api import FileAPI
+from unittest.mock import Mock
+import pytest
+from data_pipeline_api.file_api import FileAPI, FileAccess, ReadAccess, WriteAccess
 
 logging.basicConfig(level="DEBUG")
 
@@ -153,3 +154,110 @@ def test_access_file_contains_run_metadata(tmp_path):
     with FileAPI():
         pass
     assert (tmp_path / "access.yaml").exists()
+
+
+def test_file_access_to_access_log_record():
+    assert FileAccess(
+        "test", {"call": "call"}, {"calculated_hash": "access"}, "test"
+    ).to_access_log_record() == {
+        "timestamp": "test",
+        "call_metadata": {"call": "call"},
+        "access_metadata": {"calculated_hash": "access"},
+    }
+
+
+def test_file_access_to_access_log_record_prefers_access_metadata(tmp_path):
+    assert FileAccess(
+        1, {"call": "call"}, {"calculated_hash": "access"}, tmp_path
+    ).to_access_log_record({tmp_path.resolve(): "test"}) == {
+        "timestamp": 1,
+        "call_metadata": {"call": "call"},
+        "access_metadata": {"calculated_hash": "access"},
+    }
+
+
+def test_file_access_to_access_log_record_uses_cache_if_not_in_metadata(tmp_path):
+    assert FileAccess(1, {"call": "call"}, {}, tmp_path).to_access_log_record(
+        {tmp_path.resolve(): "test"}
+    ) == {
+        "timestamp": 1,
+        "call_metadata": {"call": "call"},
+        "access_metadata": {"calculated_hash": "test"},
+    }
+
+
+def test_file_access_to_access_log_record_calculates_hash_if_not_found(tmp_path):
+    with open(tmp_path / "test.txt", "w") as file:
+        file.write("hello")
+    assert FileAccess(
+        1, {"call": "call"}, {}, tmp_path / "test.txt"
+    ).to_access_log_record({}) == {
+        "timestamp": 1,
+        "call_metadata": {"call": "call"},
+        "access_metadata": {
+            "calculated_hash": "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+        },
+    }
+
+
+def test_file_access_to_access_log_record_raises_on_invalid_path(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        assert FileAccess(
+            1, {"call": "call"}, {}, tmp_path / "test.txt"
+        ).to_access_log_record({})
+
+
+def test_read_access():
+    assert ReadAccess(
+        "test", {"call": "call"}, {"calculated_hash": "access"}, "test"
+    ).to_access_log_record() == {
+        "type": "read",
+        "timestamp": "test",
+        "call_metadata": {"call": "call"},
+        "access_metadata": {"calculated_hash": "access"},
+    }
+
+
+def test_write_access(tmp_path):
+    assert WriteAccess(
+        "test",
+        {"call": "call"},
+        {"calculated_hash": "access"},
+        "test",
+        open(tmp_path / "test.txt", "w"),
+    ).to_access_log_record() == {
+        "type": "write",
+        "timestamp": "test",
+        "call_metadata": {"call": "call"},
+        "access_metadata": {"calculated_hash": "access"},
+    }
+
+
+def test_write_access_flushes_open_file(tmp_path):
+    file = open(tmp_path / "test.txt", "w")
+    file.flush = Mock()
+    WriteAccess(
+        "test", {"call": "call"}, {"calculated_hash": "access"}, "test", file
+    ).to_access_log_record()
+    file.flush.assert_called_once()
+    file.close()
+
+
+def test_generate_access_log(configuration_file):
+    file_api = FileAPI(configuration_file)
+    file_api.open_for_read(data_product="test", version="1.0.0").close()
+    file_api.open_for_write(data_product="test2", extension="txt").close()
+    assert len(file_api._generate_access_log()["io"]) == 2
+
+
+def test_multiple_writes_to_same_file_record_same_hash(configuration_file):
+    file_api = FileAPI(configuration_file)
+    with file_api.open_for_write(data_product="test", extension="txt") as file:
+        file.write("foo".encode())
+    with file_api.open_for_write(data_product="test", extension="txt") as file:
+        file.write("bar".encode())
+    access_log = file_api._generate_access_log()
+    assert (
+        access_log["io"][0]["access_metadata"]["calculated_hash"]
+        == access_log["io"][1]["access_metadata"]["calculated_hash"]
+    )


### PR DESCRIPTION
This now records the write accesses as they happen but doesn't record the hash, and then calculates them all (with caching to avoid calculating any more than once) at the end. In "interface" *structure* terms, i.e. the access.yaml, this shouldn't have changed anything, though of course the hashes for a given sequence of writes might now be different.