### PR TITLE
Added R API Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ pytest --cov=data_pipeline_api tests
 
 **ToDo**
 
+### Using the API in R
+
+A description of how to use this API in R is given [here](r_api/README.md).
+
 # Current issues and questions
 
 **ToDo** Migrate these to GitHub issues.


### PR DESCRIPTION
Addition of `r_api` folder which just contains instructions on how to use the API via the `reticulate` library in R