### PR TITLE
Data directory to be placed at root of config file 

### DIFF
--- a/java_api/file_api/src/test/resources/config.yaml
+++ b/java_api/file_api/src/test/resources/config.yaml
@@ -1,6 +1,4 @@
-run_metadata:
-  data_directory: folder/data
-
+data_directory: folder/data
 access_log: access-{run_id}.yaml
 fail_on_hash_mismatch: True
 run_id: runId


### PR DESCRIPTION
Data directory to be placed at root of config file instead of within run_metadata


There was a failing test, last PR got merged too quickly!