### PR TITLE
test_git_info.py: Allow ssh remote URL

### DIFF
--- a/tests/test_git_info.py
+++ b/tests/test_git_info.py
@@ -24,7 +24,8 @@ def test_get_repo_info():
     if git_installed:
         assert (
             repo_info.uri
-            == "https://github.com/ScottishCovidResponse/data_pipeline_api.git"
+            in ["https://github.com/ScottishCovidResponse/data_pipeline_api.git",
+                "git@github.com:ScottishCovidResponse/data_pipeline_api.git"]
         )
     else:
         assert repo_info == RepoInfo(git_sha="", uri="default_repo", is_dirty=True)


### PR DESCRIPTION
See https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/729. Allow ssh remote URL in test_git_info.py.
