### PR TITLE
Fixed incorrect binomial distribution in CPP bindings

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -32,8 +32,6 @@ SET( CMAKE_THREAD_LIBS_INIT "-lpthread" )
 SET( SRCFILES array.cc distributions.cc datapipeline.cc table.cc )
 get_filename_component( BINDINGS_ROOT ${CMAKE_SOURCE_DIR} DIRECTORY )
 get_filename_component( DATA_PIPELINE_ROOT ${BINDINGS_ROOT} DIRECTORY )
-SET( PYTHON_CFLAGS "${PYTHON_EXTRA_CFLAGS} ${PYCFLAGS} -UNDEBUG -fPIC" )
-SET( PYTHON_LDFLAGS "${PYTHON_EXTRA_LDFLAGS} ${PYLDFLAGS}" )
 set( CMAKE_CXX_FLAGS "-DROOTDIR=\\\"${DATA_PIPELINE_ROOT}\\\" -DGIT_URL=\\\"${GIT_REMOTE_URL}\\\" -DVERSION=\\\"${SOFT_VERSION}\\\"" )
 
 find_package(PythonLibs 3 REQUIRED)

--- a/bindings/cpp/datapipeline.cc
+++ b/bindings/cpp/datapipeline.cc
@@ -71,6 +71,9 @@ Table DataPipeline::read_table(const string &data_product, const string &compone
       // TODO: long isn't 64 bits on Windows or 32 bit systems
       vector<long> values = dataframe[colname.c_str()].attr("tolist")().cast<vector<long>>();
       table.add_column<long>(colname, values);
+    } else if (dtype == "int32") {
+      vector<int> values = dataframe[colname.c_str()].attr("tolist")().cast<vector<int>>();
+      table.add_column<int>(colname, values);
     } else {
       cout << "WARNING: Converting column " << colname << " from unsupported type " << dtype << " to string" << endl;
 

--- a/bindings/cpp/distributions.cc
+++ b/bindings/cpp/distributions.cc
@@ -73,10 +73,9 @@ Distribution todis_beta(pybind11::object d_py)
 Distribution todis_binomial(pybind11::object d_py)
 {
     const string name = "binomial";
-    const double n = d_py.attr("n").cast<double>();
-    const std::vector<double> p = d_py.attr("p").cast<vector<double>>();
+    const vector<double> args = d_py.attr("args").cast<vector<double>>();
 
-    return Distribution(name, {{"n", n}}, {{"p", p}});
+    return Distribution(name, {{"n", args[0]}, {"p", args[1]}});
 }
 
 Distribution todis_multinomial(pybind11::object d_py)
@@ -111,6 +110,10 @@ const Distribution get_distribution(pybind11::object d_py)
     else if(name == "binom")
     {
         return todis_poisson(d_py);
+    }
+    else if(name == "beta")
+    {
+        return todis_beta(d_py);
     }
     else if(name == "expon")
     {

--- a/bindings/cpp/tests/CMakeLists.txt
+++ b/bindings/cpp/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ MESSAGE(STATUS "\tGMOCK: ${GMOCK_INCLUDE_DIRS}")
 MESSAGE(STATUS "\tFLAGS: ${CMAKE_CXX_FLAGS}")
 MESSAGE(STATUS "----------------------------------")
 
-target_link_libraries(${TEST_NAME} PRIVATE ${PROJECT_NAME} ${PROJECT_LIBS} ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
+target_link_libraries(${TEST_NAME} PRIVATE ${PROJECT_NAME} ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
 
 include(GoogleTest)
 gtest_discover_tests(${TEST_NAME})

--- a/bindings/cpp/tests/test_distribution_class.cc
+++ b/bindings/cpp/tests/test_distribution_class.cc
@@ -21,4 +21,16 @@ TEST_F(SCRCAPITest, TestDistributionPrint)
 {
    Distribution _dis = todis_gamma(Gamma(10,10));
    EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
+   _dis = todis_poisson(Poisson(10));
+   EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
+   _dis = todis_multinomial(Multinomial(3, {4,5,6}));
+   EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
+   _dis = todis_binomial(Binomial(3, 7));
+   EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
+   _dis = todis_uniform(Uniform(3, 7));
+   EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
+   _dis = todis_beta(Beta(3, 7));
+   EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
+   _dis = todis_normal(Normal(3, 7));
+   EXPECT_NO_FATAL_FAILURE(std::cout << _dis << std::endl);
 }


### PR DESCRIPTION
* Definition of the function `todis_binomial` in the C++ bindings was incorrect this is now picked up by the improved unit test and fixed in this patch.
* Also added `int32` column for `readtable` resulting in an `int` STL vector.
* Added missing `todis_beta` function.