### PR TITLE
Add in close to destructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ repos/*
 
 # sphinx / readthedocs
 doc/build/*
+
+# tests directories
+tests/data/output*
+tests/data/access*.yaml
+bindings/cpp/tests/output*

--- a/bindings/cpp/datapipeline.cc
+++ b/bindings/cpp/datapipeline.cc
@@ -12,6 +12,11 @@ DataPipeline::DataPipeline(const string &config_file, const string &uri, const s
   api(py::module::import("data_pipeline_api.standard_api").attr("StandardAPI").attr("from_config")(
     config_file, uri, git_sha)) {}
 
+DataPipeline::~DataPipeline()
+{
+  api.attr("file_api").attr("close")();
+}
+
 double DataPipeline::read_estimate(string data_product, const string &component)
 {
   // TODO: can we assume all estimate are floats? Should we check it?

--- a/bindings/cpp/datapipeline.hh
+++ b/bindings/cpp/datapipeline.hh
@@ -21,6 +21,7 @@ class DataPipeline
 {
   public:
   DataPipeline(const string &config_file, const string &uri, const string &git_sha);
+  ~DataPipeline();
   double read_estimate(string data_product, const string &component);
   Distribution read_distribution(const string &data_product, const string &component);
   vector<double> read_sample(const string &data_product, const string &component);


### PR DESCRIPTION
Small change to add the file API close method call to the data pipeline object destructor. Also, modified the .gitignore to remove the C++ unit test outputs.

Fixes ScottishCovidResponse/SCRCIssueTracking#752