### PR TITLE
Travis secrets test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     - name: 'Conda Python with .yml-file'
       language: python
       install:
+        - sh -c "echo anaconda token is $ANACONDA_TOKEN"
         - sudo apt-get update && sudo apt-get install -y wget
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
         - bash miniconda.sh -b -p $HOME/miniconda


### PR DESCRIPTION
To double-check that malicious PRs from forks can't be used to decrypt and expose Travis secrets.